### PR TITLE
[FIX] l10n_ec_account_edi: on test, refresh edi_doc after button_draft

### DIFF
--- a/l10n_ec_account_edi/tests/test_l10n_ec_edi_out_invoice.py
+++ b/l10n_ec_account_edi/tests/test_l10n_ec_edi_out_invoice.py
@@ -156,6 +156,7 @@ class TestL10nClDte(TestL10nECEdiCommon):
         # Enviar contexto para presentar clave de acceso de xml erroneo
         invoice.button_draft()
         invoice.action_post()
+        edi_doc = invoice._get_edi_document(self.edi_format)
         with self.assertLogs(
             "odoo.addons.l10n_ec_account_edi.models.account_edi_document",
             level=logging.ERROR,


### PR DESCRIPTION
odoo delete edi.documents when move is back to draft complementary to commit https://github.com/odoo/odoo/commit/765f77f7536e1bd7f3f74ea7f407ce8d846adf87