### PR TITLE
[FIX] l10n_ec_account_edi: Use the payment method from the invoice in…

### DIFF
--- a/l10n_ec_account_edi/models/account_move.py
+++ b/l10n_ec_account_edi/models/account_move.py
@@ -140,7 +140,9 @@ class AccountMove(models.Model):
                 )
             payment_data.append(payment_vals)
         if not payment_data:
-            l10n_ec_sri_payment = self.journal_id.l10n_ec_sri_payment_id
+            l10n_ec_sri_payment = (
+                self.l10n_ec_sri_payment_id or self.journal_id.l10n_ec_sri_payment_id
+            )
             payment_vals = {
                 "name": l10n_ec_sri_payment.name,
                 "formaPago": l10n_ec_sri_payment.code,


### PR DESCRIPTION
…stead of the journal.

Before this commit, the payment method was being taken from the journal, but it should be taken from the invoice. The payment method is required to generate withholdings.