### PR TITLE
[IMP] l10n_ec_account_edi: Validate partner VAT before posting electronic document

### DIFF
--- a/l10n_ec_account_edi/models/account_edi_format.py
+++ b/l10n_ec_account_edi/models/account_edi_format.py
@@ -162,12 +162,20 @@ class AccountEdiFormat(models.Model):
                         )
                     )
             # TODO: agregar logica para demas tipos de documento
-            errors.extend(self._l10n_ec_check_edi_configuration(journal, company))
+            errors.extend(self._l10n_ec_check_edi_configuration(document, company))
         return errors
 
-    def _l10n_ec_check_edi_configuration(self, journal, company):
+    def _l10n_ec_check_edi_configuration(self, document, company):
+        journal = document.journal_id
         errors = []
         contact_address = journal.l10n_ec_emission_address_id
+        if not document.commercial_partner_id.vat:
+            errors.append(
+                _(
+                    "You must set vat identification for Partner: %s",
+                    document.commercial_partner_id.display_name,
+                )
+            )
         if not company.vat:
             errors.append(
                 _(


### PR DESCRIPTION

Prior to this commit, it was possible to post an invoice without the partner's VAT, but the XML would be rejected. After this commit, an exception is raised if the partner's VAT is missing, ensuring proper validation before posting the electronic document.

Additionally, adapt the test to accommodate the new exception raised before posting.