### PR TITLE
[IMP] l10n_ec_account_edi: Load WSDL definition locally instead of from SRI

### DIFF
--- a/l10n_ec_account_edi/tests/sri_response.py
+++ b/l10n_ec_account_edi/tests/sri_response.py
@@ -4,14 +4,17 @@ from unittest.mock import create_autospec, patch
 from zeep import Client
 from zeep.transports import Transport
 
+from odoo.tools.misc import file_path
+
 from odoo.addons.l10n_ec_account_edi.models.account_edi_format import (
-    PRODUCTION_URL,
     AccountEdiFormat,
 )
 
-ws_url = PRODUCTION_URL.get("reception")
+soap_file_path = file_path(
+    "l10n_ec_account_edi/tests/wsdl/RecepcionComprobantesOffline?wsdl"
+)
 transport = Transport(timeout=30)
-wsClient = Client(ws_url, transport=transport)
+wsClient = Client(soap_file_path, transport=transport)
 factory = wsClient.type_factory("ns0")
 
 sri_message_date = factory.mensaje(
@@ -46,8 +49,10 @@ validation_sri_response_returned = factory.respuestaSolicitud(
     },
 )
 
-ws_url = PRODUCTION_URL.get("authorization")
-wsClient = Client(ws_url, transport=transport)
+soap_file_path = file_path(
+    "l10n_ec_account_edi/tests/wsdl/AutorizacionComprobantesOffline?wsdl"
+)
+wsClient = Client(soap_file_path, transport=transport)
 factory = wsClient.type_factory("ns0")
 
 auth_sri_response = factory.respuestaComprobante(

--- a/l10n_ec_account_edi/tests/wsdl/AutorizacionComprobantesOffline?wsdl
+++ b/l10n_ec_account_edi/tests/wsdl/AutorizacionComprobantesOffline?wsdl
@@ -1,0 +1,131 @@
+<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://ec.gob.sri.ws.autorizacion" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="AutorizacionComprobantesOfflineService" targetNamespace="http://ec.gob.sri.ws.autorizacion">
+<wsdl:types>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://ec.gob.sri.ws.autorizacion" elementFormDefault="unqualified" targetNamespace="http://ec.gob.sri.ws.autorizacion" version="1.0">
+<xs:element name="RespuestaAutorizacion" nillable="true" type="xs:anyType"/>
+<xs:element name="autorizacion" type="tns:autorizacion"/>
+<xs:element name="autorizacionComprobante" type="tns:autorizacionComprobante"/>
+<xs:element name="autorizacionComprobanteLote" type="tns:autorizacionComprobanteLote"/>
+<xs:element name="autorizacionComprobanteLoteResponse" type="tns:autorizacionComprobanteLoteResponse"/>
+<xs:element name="autorizacionComprobanteResponse" type="tns:autorizacionComprobanteResponse"/>
+<xs:element name="mensaje" type="tns:mensaje"/>
+<xs:complexType name="autorizacionComprobante">
+<xs:sequence>
+<xs:element minOccurs="0" name="claveAccesoComprobante" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="autorizacionComprobanteResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="RespuestaAutorizacionComprobante" type="tns:respuestaComprobante"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="respuestaComprobante">
+<xs:sequence>
+<xs:element minOccurs="0" name="claveAccesoConsultada" type="xs:string"/>
+<xs:element minOccurs="0" name="numeroComprobantes" type="xs:string"/>
+<xs:element minOccurs="0" name="autorizaciones">
+<xs:complexType>
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" ref="tns:autorizacion"/>
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="autorizacion">
+<xs:sequence>
+<xs:element minOccurs="0" name="estado" type="xs:string"/>
+<xs:element minOccurs="0" name="numeroAutorizacion" type="xs:string"/>
+<xs:element minOccurs="0" name="fechaAutorizacion" type="xs:dateTime"/>
+<xs:element minOccurs="0" name="ambiente" type="xs:string"/>
+<xs:element minOccurs="0" name="comprobante" type="xs:string"/>
+<xs:element minOccurs="0" name="mensajes">
+<xs:complexType>
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" ref="tns:mensaje"/>
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="mensaje">
+<xs:sequence>
+<xs:element minOccurs="0" name="identificador" type="xs:string"/>
+<xs:element minOccurs="0" name="mensaje" type="xs:string"/>
+<xs:element minOccurs="0" name="informacionAdicional" type="xs:string"/>
+<xs:element minOccurs="0" name="tipo" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="autorizacionComprobanteLote">
+<xs:sequence>
+<xs:element minOccurs="0" name="claveAccesoLote" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="autorizacionComprobanteLoteResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="RespuestaAutorizacionLote" type="tns:respuestaLote"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="respuestaLote">
+<xs:sequence>
+<xs:element minOccurs="0" name="claveAccesoLoteConsultada" type="xs:string"/>
+<xs:element minOccurs="0" name="numeroComprobantesLote" type="xs:string"/>
+<xs:element minOccurs="0" name="autorizaciones">
+<xs:complexType>
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" ref="tns:autorizacion"/>
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+</xs:sequence>
+</xs:complexType>
+</xs:schema>
+</wsdl:types>
+<wsdl:message name="autorizacionComprobanteLote">
+<wsdl:part element="tns:autorizacionComprobanteLote" name="parameters"> </wsdl:part>
+</wsdl:message>
+<wsdl:message name="autorizacionComprobanteResponse">
+<wsdl:part element="tns:autorizacionComprobanteResponse" name="parameters"> </wsdl:part>
+</wsdl:message>
+<wsdl:message name="autorizacionComprobanteLoteResponse">
+<wsdl:part element="tns:autorizacionComprobanteLoteResponse" name="parameters"> </wsdl:part>
+</wsdl:message>
+<wsdl:message name="autorizacionComprobante">
+<wsdl:part element="tns:autorizacionComprobante" name="parameters"> </wsdl:part>
+</wsdl:message>
+<wsdl:portType name="AutorizacionComprobantesOffline">
+<wsdl:operation name="autorizacionComprobante">
+<wsdl:input message="tns:autorizacionComprobante" name="autorizacionComprobante"> </wsdl:input>
+<wsdl:output message="tns:autorizacionComprobanteResponse" name="autorizacionComprobanteResponse"> </wsdl:output>
+</wsdl:operation>
+<wsdl:operation name="autorizacionComprobanteLote">
+<wsdl:input message="tns:autorizacionComprobanteLote" name="autorizacionComprobanteLote"> </wsdl:input>
+<wsdl:output message="tns:autorizacionComprobanteLoteResponse" name="autorizacionComprobanteLoteResponse"> </wsdl:output>
+</wsdl:operation>
+</wsdl:portType>
+<wsdl:binding name="AutorizacionComprobantesOfflineServiceSoapBinding" type="tns:AutorizacionComprobantesOffline">
+<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+<wsdl:operation name="autorizacionComprobante">
+<soap:operation soapAction="" style="document"/>
+<wsdl:input name="autorizacionComprobante">
+<soap:body use="literal"/>
+</wsdl:input>
+<wsdl:output name="autorizacionComprobanteResponse">
+<soap:body use="literal"/>
+</wsdl:output>
+</wsdl:operation>
+<wsdl:operation name="autorizacionComprobanteLote">
+<soap:operation soapAction="" style="document"/>
+<wsdl:input name="autorizacionComprobanteLote">
+<soap:body use="literal"/>
+</wsdl:input>
+<wsdl:output name="autorizacionComprobanteLoteResponse">
+<soap:body use="literal"/>
+</wsdl:output>
+</wsdl:operation>
+</wsdl:binding>
+<wsdl:service name="AutorizacionComprobantesOfflineService">
+<wsdl:port binding="tns:AutorizacionComprobantesOfflineServiceSoapBinding" name="AutorizacionComprobantesOfflinePort">
+<soap:address location="http://localhost/comprobantes-electronicos-ws/AutorizacionComprobantesOffline"/>
+</wsdl:port>
+</wsdl:service>
+</wsdl:definitions>

--- a/l10n_ec_account_edi/tests/wsdl/RecepcionComprobantesOffline?wsdl
+++ b/l10n_ec_account_edi/tests/wsdl/RecepcionComprobantesOffline?wsdl
@@ -1,0 +1,82 @@
+<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://ec.gob.sri.ws.recepcion" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="RecepcionComprobantesOfflineService" targetNamespace="http://ec.gob.sri.ws.recepcion">
+<wsdl:types>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://ec.gob.sri.ws.recepcion" elementFormDefault="unqualified" targetNamespace="http://ec.gob.sri.ws.recepcion" version="1.0">
+<xs:element name="RespuestaSolicitud" type="tns:respuestaSolicitud"/>
+<xs:element name="comprobante" type="tns:comprobante"/>
+<xs:element name="mensaje" type="tns:mensaje"/>
+<xs:element name="validarComprobante" type="tns:validarComprobante"/>
+<xs:element name="validarComprobanteResponse" type="tns:validarComprobanteResponse"/>
+<xs:complexType name="validarComprobante">
+<xs:sequence>
+<xs:element minOccurs="0" name="xml" type="xs:base64Binary"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="validarComprobanteResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="RespuestaRecepcionComprobante" type="tns:respuestaSolicitud"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="respuestaSolicitud">
+<xs:sequence>
+<xs:element minOccurs="0" name="estado" type="xs:string"/>
+<xs:element minOccurs="0" name="comprobantes">
+<xs:complexType>
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" ref="tns:comprobante"/>
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="comprobante">
+<xs:sequence>
+<xs:element minOccurs="0" name="claveAcceso" type="xs:string"/>
+<xs:element minOccurs="0" name="mensajes">
+<xs:complexType>
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" ref="tns:mensaje"/>
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="mensaje">
+<xs:sequence>
+<xs:element minOccurs="0" name="identificador" type="xs:string"/>
+<xs:element minOccurs="0" name="mensaje" type="xs:string"/>
+<xs:element minOccurs="0" name="informacionAdicional" type="xs:string"/>
+<xs:element minOccurs="0" name="tipo" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+</xs:schema>
+</wsdl:types>
+<wsdl:message name="validarComprobanteResponse">
+<wsdl:part element="tns:validarComprobanteResponse" name="parameters"> </wsdl:part>
+</wsdl:message>
+<wsdl:message name="validarComprobante">
+<wsdl:part element="tns:validarComprobante" name="parameters"> </wsdl:part>
+</wsdl:message>
+<wsdl:portType name="RecepcionComprobantesOffline">
+<wsdl:operation name="validarComprobante">
+<wsdl:input message="tns:validarComprobante" name="validarComprobante"> </wsdl:input>
+<wsdl:output message="tns:validarComprobanteResponse" name="validarComprobanteResponse"> </wsdl:output>
+</wsdl:operation>
+</wsdl:portType>
+<wsdl:binding name="RecepcionComprobantesOfflineServiceSoapBinding" type="tns:RecepcionComprobantesOffline">
+<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+<wsdl:operation name="validarComprobante">
+<soap:operation soapAction="" style="document"/>
+<wsdl:input name="validarComprobante">
+<soap:body use="literal"/>
+</wsdl:input>
+<wsdl:output name="validarComprobanteResponse">
+<soap:body use="literal"/>
+</wsdl:output>
+</wsdl:operation>
+</wsdl:binding>
+<wsdl:service name="RecepcionComprobantesOfflineService">
+<wsdl:port binding="tns:RecepcionComprobantesOfflineServiceSoapBinding" name="RecepcionComprobantesOfflinePort">
+<soap:address location="http://localhost/comprobantes-electronicos-ws/RecepcionComprobantesOffline"/>
+</wsdl:port>
+</wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
When the SRI web services are down, the test is not successful. Therefore, it is better to load the definition locally to avoid errors.