### PR TITLE
[17.0][FIX] l10n_ec_withhold: correctly use the field to avoid errors

### DIFF
--- a/l10n_ec_withhold/models/account_move.py
+++ b/l10n_ec_withhold/models/account_move.py
@@ -257,7 +257,7 @@ class AccountMove(models.Model):
     def is_withhold(self):
         return (
             self.country_code == "EC"
-            and self.l10n_latam_internal_type == "withhold"
+            and self.l10n_latam_document_type_id.internal_type == "withhold"
             and self.l10n_ec_withholding_type in self.get_withhold_types()
         )
 


### PR DESCRIPTION
This field is a related field and is sometimes empty; it's better to take it from the original field.
@HLEE1254 could you try with these changes

closes #72 