### PR TITLE
[FIX] OwlError in Settings view when searching in Odoo 17

### DIFF
--- a/l10n_ec_account_edi/views/res_config_settings_view.xml
+++ b/l10n_ec_account_edi/views/res_config_settings_view.xml
@@ -6,23 +6,12 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//block[@id='invoicing_settings']" position="after">
-                <div id="l10n_ec_title" invisible="country_code != 'EC'">
-                    <h2>Ecuadorian Localization</h2>
-                </div>
-                <div
-                    id="l10n_ec_section"
-                    class="row mt16 o_settings_container"
-                    invisible="country_code != 'EC'"
-                >
-                    <div
-                        class="col-12 col-lg-6 o_setting_box"
-                        title="Electronic Invoicing Connection Parameters"
-                    >
-                        <div class="o_setting_left_pane" />
-                        <div class="o_setting_right_pane">
-                            <span
-                                class="o_form_label"
-                            >Electronic Invoicing Connection Parameters</span>
+                <block title="Ecuadorian Localization" invisible="country_code != 'EC'">
+                    <div id="l10n_ec_section">
+                        <setting
+                            string="Electronic Invoicing Connection Parameters"
+                            title="Electronic Invoicing Connection Parameters"
+                        >
                             <div class="content-group">
                                 <div class="row">
                                     <label
@@ -36,17 +25,11 @@
                                     />
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                    <div
-                        class="col-12 col-lg-6 o_setting_box"
-                        title="Electronic Certificate File"
-                    >
-                        <div class="o_setting_left_pane" />
-                        <div class="o_setting_right_pane">
-                            <span
-                                class="o_form_label"
-                            >Electronic Certificate File</span>
+                        </setting>
+                        <setting
+                            string="Electronic Certificate File"
+                            title="Electronic Certificate File"
+                        >
                             <div class="content-group">
                                 <div class="row">
                                     <label
@@ -61,13 +44,9 @@
                                     />
                                 </div>
                             </div>
-                        </div>
-                    </div>
+                        </setting>
 <!--                    Configurar Limite del valor de factura a Consumidor Final -->
-                    <div class="col-12 col-lg-6 o_setting_box" title="Final Consumer">
-                        <div class="o_setting_left_pane" />
-                        <div class="o_setting_right_pane">
-                            <span class="o_form_label">Final Consumer</span>
+                        <setting string="Final Consumer" title="Final Consumer">
                             <div class="text-muted">
                                  Limit for billing in sales for final consumer, total amount
                             </div>
@@ -84,12 +63,8 @@
                                     />
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_left_pane" />
-                        <div class="o_setting_right_pane">
-                            <span class="o_form_label">XML Document Version</span>
+                        </setting>
+                        <setting string="XML Document Version">
                             <div class="row col-12 oe_grey">
                                 <ul>
                                     <li>Versions 1.0.0 to 2 decimals</li>
@@ -133,9 +108,9 @@
                                     class="oe_in_line"
                                 />
                             </div>
-                        </div>
+                        </setting>
                     </div>
-                </div>
+                </block>
             </xpath>
         </field>
     </record>

--- a/l10n_ec_credit_note/views/res_config_view.xml
+++ b/l10n_ec_credit_note/views/res_config_view.xml
@@ -10,27 +10,12 @@
         />
         <field name="arch" type="xml">
             <xpath expr="//div[@id='l10n_ec_section']" position="inside">
-                <setting string="Default Accounts for  Credit Notes">
-                    <div class="content-group">
-                        <div class="row mt8">
-                            <label
-                                for="l10n_ec_property_account_discount_id"
-                                class="col-lg-5 o_light_label"
-                                string="C.C. Discount"
-                            />
-                            <field name="l10n_ec_property_account_discount_id" />
-                        </div>
-                        <div class="row mt8">
-                            <label
-                                for="l10n_ec_property_account_return_id"
-                                class="col-lg-5 o_light_label"
-                                string="C.C. Refund"
-                            />
-                            <field name="l10n_ec_property_account_return_id" />
-                        </div>
-                    </div>
-
-                </setting>
+                <group>
+                    <group string="Default Accounts for Credit Notes">
+                        <field name="l10n_ec_property_account_discount_id" />
+                        <field name="l10n_ec_property_account_return_id" />
+                    </group>
+                </group>
             </xpath>
         </field>
     </record>

--- a/l10n_ec_credit_note/views/res_config_view.xml
+++ b/l10n_ec_credit_note/views/res_config_view.xml
@@ -10,12 +10,27 @@
         />
         <field name="arch" type="xml">
             <xpath expr="//div[@id='l10n_ec_section']" position="inside">
-                <group>
-                    <group string="Default Accounts for Credit Notes">
-                        <field name="l10n_ec_property_account_discount_id" />
-                        <field name="l10n_ec_property_account_return_id" />
-                    </group>
-                </group>
+                <setting string="Default Accounts for  Credit Notes">
+                    <div class="content-group">
+                        <div class="row mt8">
+                            <label
+                                for="l10n_ec_property_account_discount_id"
+                                class="col-lg-5 o_light_label"
+                                string="C.C. Discount"
+                            />
+                            <field name="l10n_ec_property_account_discount_id" />
+                        </div>
+                        <div class="row mt8">
+                            <label
+                                for="l10n_ec_property_account_return_id"
+                                class="col-lg-5 o_light_label"
+                                string="C.C. Refund"
+                            />
+                            <field name="l10n_ec_property_account_return_id" />
+                        </div>
+                    </div>
+
+                </setting>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Este PR corrige un error de interfaz (OwlError) que ocurría en Odoo 17 al buscar cualquier término en la barra de búsqueda dentro del menú Ajustes → Configuración cuando estaba instalado el módulo l10n_ec_credit_note.

El problema era causado por el uso de la etiqueta <setting> en la vista heredada res.config.settings, la cual fue deprecada en Odoo 17.
Al intentar renderizar o filtrar las opciones de configuración, el framework OWL intentaba acceder a propiedades internas de un componente inexistente (showAllContainer), lo que provocaba el error:

<img width="651" height="746" alt="image" src="https://github.com/user-attachments/assets/3164b6fa-71ad-4c03-90ab-e97a07f86474" />

🧪 Cómo reproducir el error

1. Instalar el módulo l10n_ec_credit_note.
2. Ir al menú Ajustes → Configuración.
3. Escribir cualquier texto en la barra de búsqueda superior de Ajustes.
4. Odoo mostrará una ventana emergente con el error de cliente:

```
OwlError: An error occured in the owl lifecycle
Caused by: TypeError: Cannot read properties of undefined (reading 'showAllContainer')
```

Se reemplazó el uso del nodo <setting> por una estructura estándar basada en <group>, asegurando compatibilidad con la nueva arquitectura de vistas de configuración.

Archivo modificado:
`views/res_config_view.xml`