### PR TITLE
[17.0][FIX] Actualizado para firmar archivos XML con un certificado emitidio por UANATACA

### DIFF
--- a/l10n_ec_account_edi/models/sri_key_type.py
+++ b/l10n_ec_account_edi/models/sri_key_type.py
@@ -20,7 +20,7 @@ from odoo.tools.translate import _
 _logger = logging.getLogger(__name__)
 
 KEY_TO_PEM_CMD = (
-    "openssl pkcs12 -nocerts -in %s -out %s -passin pass:%s -passout pass:%s"
+    "openssl pkcs12 -nocerts -in %s -out %s -legacy -passin pass:%s -passout pass:%s"
 )
 
 


### PR DESCRIPTION
Actualizado para firmar archivos XML con un certificado emitidio por UANATACA emitidio por UANATACA. Está probado con BCE y Security Data