### PR TITLE
[17.0][FIX] l10n_ec_account_edi: set totalDescuento to 2 decimal places per SRI XSD

### DIFF
--- a/l10n_ec_account_edi/models/account_edi_document.py
+++ b/l10n_ec_account_edi/models/account_edi_document.py
@@ -390,7 +390,7 @@ class AccountEdiDocument(models.Model):
             )[:300],
             "totalSinImpuestos": self._l10n_ec_number_format(invoice.amount_untaxed, 6),
             "totalDescuento": self._l10n_ec_number_format(
-                self._l10n_ec_compute_amount_discount(), 6
+                self._l10n_ec_compute_amount_discount(), 2
             ),
             "totalConImpuestos": self.l10n_ec_header_get_total_with_taxes(taxes_data),
             "compensaciones": [],
@@ -436,7 +436,7 @@ class AccountEdiDocument(models.Model):
             )[:300],
             "totalSinImpuestos": self._l10n_ec_number_format(invoice.amount_untaxed, 6),
             "totalDescuento": self._l10n_ec_number_format(
-                self._l10n_ec_compute_amount_discount(), 6
+                self._l10n_ec_compute_amount_discount(), 2
             ),
             "totalConImpuestos": self.l10n_ec_header_get_total_with_taxes(taxes_data),
             "compensaciones": [],
@@ -491,7 +491,7 @@ class AccountEdiDocument(models.Model):
                 credit_note.amount_untaxed, 6
             ),
             "totalDescuento": self._l10n_ec_number_format(
-                self._l10n_ec_compute_amount_discount(), 6
+                self._l10n_ec_compute_amount_discount(), 2
             ),
             "totalConImpuestos": self.l10n_ec_header_get_total_with_taxes(taxes_data),
             "compensaciones": [],

--- a/l10n_ec_account_edi/tests/test_l10n_ec_edi_out_invoice.py
+++ b/l10n_ec_account_edi/tests/test_l10n_ec_edi_out_invoice.py
@@ -327,3 +327,25 @@ class TestL10nOutInvoice(TestL10nECEdiCommon):
         # 1 = test
         # 2 = Production
         self.assertEqual(edi_doc.l10n_ec_xml_access_key[23], "2")
+
+    def test_l10n_ec_out_invoice_discount_decimal_precision(self):
+        """totalDescuento must not exceed 2 decimal places as required by the
+        SRI XSD (fractionDigits=2). A discount of 33.33% on a 10.00 unit price
+        produces 3.333 which caused SRI rejection when serialized with 6 decimals.
+        """
+        self._setup_edi_company_ec()
+        invoice = self._l10n_ec_prepare_edi_out_invoice()
+        with Form(invoice) as form:
+            with form.invoice_line_ids.edit(0) as line:
+                line.price_unit = 10.00
+                line.discount = 33.33
+        invoice.action_post()
+        edi_doc = invoice._get_edi_document(self.edi_format)
+        info = edi_doc._l10n_ec_get_info_invoice()
+        total_descuento = info["totalDescuento"]
+        # float_repr returns a string; must have exactly 2 decimal places
+        self.assertRegex(
+            total_descuento,
+            r"^\d+\.\d{2}$",
+            "totalDescuento must have exactly 2 decimal places per SRI XSD",
+        )


### PR DESCRIPTION
## Description

The SRI XSD schema defines `fractionDigits=2` for `totalDescuento`, but the field was being serialized with 6 decimal places. This caused the SRI to reject the XML with:

```
Element 'totalDescuento': The value '3.333000' has more fractional digits than are allowed ('2').
```

### Root cause

In `_l10n_ec_get_info_invoice`, `_l10n_ec_get_info_liquidation` and `_l10n_ec_get_info_credit_note`, the call to `_l10n_ec_number_format` for `totalDescuento` was passing `decimals=6` instead of `decimals=2`:

```python
# Before
"totalDescuento": self._l10n_ec_number_format(
    self._l10n_ec_compute_amount_discount(), 6
),

# After
"totalDescuento": self._l10n_ec_number_format(
    self._l10n_ec_compute_amount_discount(), 2
),
```

### Changes

- Fixed 3 occurrences in `account_edi_document.py`
- Added regression test: invoice with `price_unit=10.00`, `discount=33.33%` produces `totalDescuento=3.333` before rounding, which previously caused SRI rejection

Fixes https://github.com/OCA/l10n-ecuador/issues/70